### PR TITLE
Return message if location not sent

### DIFF
--- a/app/lib/email_reminder.py
+++ b/app/lib/email_reminder.py
@@ -61,7 +61,7 @@ class EmailReminder():
             output[organizer].append(
                 {
                     'summary': event.get('summary'),
-                    'location': event.get('location'),
+                    'location': event.get('location', 'Check your calendar'),
                     'start': parse(event.get('start').get('dateTime')).strftime('%H:%M'),
                     'end': parse(event.get('end').get('dateTime')).strftime('%H:%M')
                 }

--- a/tests/app/lib/test_email_reminder.py
+++ b/tests/app/lib/test_email_reminder.py
@@ -63,7 +63,9 @@ class TestEmailReminder():
                     },
                     u'start': {
                         u'dateTime': u'2016-10-21T14:30:00',
-                    }
+                    },
+                    u'location': u'Room 101',
+                    u'summary': u'Stuff about stuff'
                 }
             ]
         }
@@ -80,7 +82,48 @@ class TestEmailReminder():
         email_reminder.send_reminders()
 
         message = server_mock.mock_calls[-3][1][2]
-        assert """Content-Type: text/html; charset="us-ascii"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\n\n<p>Hello,</p>\n\n<p>Your meeting room booking details for tomorrow are:</p>\n\n\n  <ul>\n    <li>Title: None</li>\n    <li>Room: None</li>\n    <li>Start: 14:30</li>\n    <li>End: 16:30</li>\n  </ul>\n\n\n<p>\n  <strong>Delete your room booking if you don\'t need it</strong><br>\n  If you don\'t need the room booking anymore, please delete it so someone else can use the room.\n</p>\n<p>\n  You can delete a room booking in a series without affecting your future bookings.\n</p>\n<p>\n  Read how to delete a room booking using Google Calendar:<br>\n  <a href="https://support.google.com/calendar/answer/37113?hl=en&ref_topic=3417926" target="_blank">https://support.google.com/calendar/answer/37113?hl=en&ref_topic=3417926</a>\n</p>\n<p>\n  <strong>Think about using a smaller room</strong><br>\n  If you\'ve got fewer people coming to the meeting than you first thought, it would be great if you could try moving to a smaller room.\n</p>\n<p>\n  Check if a meeting room\'s free at:<a href="https://meeting-rooms.cloudapps.digital/" target="_blank">https://meeting-rooms.cloudapps.digital/</a>\n</p>\n\n<p>\n  Thanks,<br>\n  Your friendly meeting room app\n</p>\n""" in message  # NOQA
+
+        assert """Title: Stuff about stuff\n  Room: Room 101\n  Start: 14:30\n  End: 16:30""" in message
+
+    @mock.patch('app.lib.email_reminder.EmailReminder._load_room_ids')
+    @mock.patch('app.lib.email_reminder.smtplib')
+    @mock.patch('app.lib.email_reminder.current_app')
+    def test_it_sends_the_correct_message_if_no_location_set(self, current_app, smtplib, load_room_ids):
+        load_room_ids.return_value = {'all': ['roomID']}
+        server_mock = mock.MagicMock()
+        smtplib.SMTP.return_value = server_mock
+        calendar_mock = mock.MagicMock()
+        calendar_mock.events.return_value.list.return_value.execute.return_value = {
+            'items': [
+                {
+                    u'end': {
+                        u'dateTime': u'2016-10-21T16:30:00'
+                    },
+                    u'organizer': {
+                        u'email': u'test@example.com',
+                    },
+                    u'start': {
+                        u'dateTime': u'2016-10-21T14:30:00',
+                    },
+                    u'summary': u'Stuff about stuff'
+                }
+            ]
+        }
+        current_app.config = {
+            'CALENDAR': calendar_mock,
+            'MAIL_SERVER': 'server',
+            'MAIL_PORT': 25,
+            'MAIL_USERNAME': 'chris',
+            'MAIL_PASSWORD': 'password',
+            'ADMIN_EMAIL': 'admin@example.com'
+        }
+
+        email_reminder = EmailReminder()
+        email_reminder.send_reminders()
+
+        message = server_mock.mock_calls[-3][1][2]
+
+        assert """Title: Stuff about stuff\n  Room: Check your calendar\n  Start: 14:30\n  End: 16:30""" in message
 
     @mock.patch('app.lib.email_reminder.MIMEMultipart')
     @mock.patch('app.lib.email_reminder.EmailReminder._load_room_ids')


### PR DESCRIPTION
There was a small issue found where very occasionally, for reasons
unknown, the location was not set. The email would display the location
as `None`. Now it will ask the user to check their calendar.