### PR TITLE
Use window.load instead of document.ready

### DIFF
--- a/app/static/javascripts/application.js
+++ b/app/static/javascripts/application.js
@@ -1,7 +1,7 @@
-$( document ).ready(function(){
+$(window).load(function(){
 
   var place = $( '.hour:nth-child(7)' ).offset().top
-  $('body').scrollTop(place);
+  $(window).scrollTop(place);
 
   $('.Free, .Busy').hover(
     function() {


### PR DESCRIPTION
There were issues with the scrolling not being applied. This is
potentially due to the divs not having dimensions when document.ready
fired. window.load works much better.