### PR TITLE
Update max number of calendars to 50

### DIFF
--- a/app/lib/room_list.py
+++ b/app/lib/room_list.py
@@ -37,6 +37,7 @@ class RoomList():
 
     def _build_free_busy_body(self, times, calendar_ids):
         return {
+            "calendarExpansionMax": 50,
             "timeMin": times['start'],
             "timeMax": times['end'],
             "timeZone": 'UTC',


### PR DESCRIPTION
Having over 20 calendars on the main page was causing an error from the
calendar api; `tooManyCalendarsRequested`.

This resulted in some rooms as appearing to have no bookings, as no
freebusy info was being retrieved.

The default is 20 but you can pass this option with the body to overwrite
that max. Upping it to 50 should be plenty