### PR TITLE
Add 719b The Garage

### DIFF
--- a/app/data/room_ids.json
+++ b/app/data/room_ids.json
@@ -86,6 +86,13 @@
     ]
   },
   {
+    "resourceEmail": "digital.cabinet-office.gov.uk_2d3936363939343035393535@resource.calendar.google.com",
+    "resourceName": "719b The Garage",
+    "lists": [
+      "all"
+    ]
+  },
+  {
     "resourceEmail": "digital.cabinet-office.gov.uk_57432d372d3730382d53482d3230@resource.calendar.google.com",
     "resourceName": "720 Social Space",
     "lists": [


### PR DESCRIPTION
this represents the other half of the garage when split into two spaces

it's a bit unclear how bookings work for the garage -- ie when it's split in two will both 719a and 719b be booked?